### PR TITLE
fix(regenerate): checkout repository before setup-node

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -42,15 +42,15 @@ jobs:
     needs: [metadata]
     if: needs.metadata.outputs.package-ecosystem == 'npm_and_yarn'
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{github.head_ref}}
       - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:
           cache: npm
           node-version: ${{inputs.node-version}}
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{github.head_ref}}
       - name: Regenerate parser
         run: |-
           npm ci --legacy-peer-deps


### PR DESCRIPTION
Action setup-node needs package-lock.json which is pulled by checkout.

I have created a repository from the template repo https://github.com/tree-sitter-grammars/template

It references the `regenerate` workflow but it did not work: https://github.com/imustafin/tree-sitter-eiffel/actions/runs/9373939855/job/25808834652
```
Error: Dependencies lock file is not found in /home/runner/work/tree-sitter-eiffel/tree-sitter-eiffel. Supported file patterns: package-lock.json,npm-shrinkwrap.json,yarn.lock
```

Doing the checkout before setup-node fixes the problem: https://github.com/imustafin/tree-sitter-eiffel/actions/runs/9374383250/job/25810295384