### PR TITLE
feat: allow rebuilding parser artifacts

### DIFF
--- a/.github/workflows/package-crates.yml
+++ b/.github/workflows/package-crates.yml
@@ -15,6 +15,10 @@ on:
         description: The Rust toolchain
         default: ${{vars.RUST_TOOLCHAIN || 'stable'}}
         type: string
+      generate:
+        description: Generate the parser artifacts
+        default: false
+        type: boolean
     secrets:
       CARGO_REGISTRY_TOKEN:
         description: An authentication token for crates.io
@@ -30,6 +34,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - uses: tree-sitter/setup-action@v1
+        if: ${{ inputs.generate }}
+        with:
+          install-lib: false
+      - name: Regenerate Parser
+        if: ${{ inputs.generate }}
+        run: tree-sitter generate --no-bindings
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -23,6 +23,10 @@ on:
         description: The version of the Ubuntu runner image
         default: ${{vars.UBUNTU_VERSION || '20.04'}}
         type: string
+      generate:
+        description: Generate the parser artifacts
+        default: false
+        type: boolean
     secrets:
       NODE_AUTH_TOKEN:
         description: An authentication token for npm
@@ -36,6 +40,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - uses: tree-sitter/setup-action@v1
+        if: ${{ inputs.generate }}
+        with:
+          install-lib: false
+      - name: Regenerate Parser
+        if: ${{ inputs.generate }}
+        run: tree-sitter generate --no-bindings
       - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:
@@ -72,6 +83,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - uses: tree-sitter/setup-action@v1
+        if: ${{ inputs.generate }}
+        with:
+          install-lib: false
+      - name: Regenerate Parser
+        if: ${{ inputs.generate }}
+        run: tree-sitter generate --no-bindings
       - name: Set up NodeJS
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -15,6 +15,10 @@ on:
         description: The Python version
         default: ${{vars.PYTHON_VERSION || '3.x'}}
         type: string
+      generate:
+        description: Generate the parser artifacts
+        default: false
+        type: boolean
     secrets:
       # TODO: make optional when pypi/warehouse#11096 is fixed
       PYPI_API_TOKEN:
@@ -58,6 +62,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - uses: tree-sitter/setup-action@v1
+        if: ${{ inputs.generate }}
+        with:
+          install-lib: false
+      - name: Regenerate Parser
+        if: ${{ inputs.generate }}
+        run: tree-sitter generate --no-bindings
       - name: Set up QEMU
         if: matrix.qemu_arch != ''
         uses: docker/setup-qemu-action@v3

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ inputs:
     description: The version of the Ubuntu runner image
     default: ${{vars.UBUNTU_VERSION || '20.04'}}
     type: string
+  generate:
+    description: Generate the parser artifacts
+    default: false
+    type: boolean
 secrets:
   NODE_AUTH_TOKEN:
     description: An authentication token for npm
@@ -79,6 +83,10 @@ inputs:
     description: The Rust toolchain
     default: ${{vars.RUST_TOOLCHAIN || 'stable'}}
     type: string
+  generate:
+    description: Generate the parser artifacts
+    default: false
+    type: boolean
 secrets:
   CARGO_REGISTRY_TOKEN:
     description: An authentication token for crates.io
@@ -101,6 +109,10 @@ inputs:
     description: The Python version
     default: ${{vars.PYTHON_VERSION || '3.x'}}
     type: string
+  generate:
+    description: Generate the parser artifacts
+    default: false
+    type: boolean
 secrets:
   PYPI_API_TOKEN:
     description: An authentication token for pypi


### PR DESCRIPTION
## What

The [DerekStride/tree-sitter-sql](https://github.com/DerekStride/tree-sitter-sql) project doesn't have the parser artifacts published to the main branch and needs the python workflow to allow optionally regenerating them.

This PR adds a new input that will run `tree-sitter generate` when set to true.

## Questions

- What's a good input parameter name? I started with `rebuild-parser`
- How should the regeneration be done? I reused the steps from the `regenerate.yml` workflow but that required setting up Node.
  - The [setup-action](https://github.com/tree-sitter/setup-action) might be a better option

https://github.com/tree-sitter/workflows/blob/614fc2245a84ffa47237a46e12f733f8ed7e00dc/.github/workflows/regenerate.yml#L49-L57