### PR TITLE
fix: BSD find (used on macos) find requires a starting position

### DIFF
--- a/.github/workflows/package-crates.yml
+++ b/.github/workflows/package-crates.yml
@@ -55,7 +55,7 @@ jobs:
             cd "$grammar_dir"
             tree-sitter generate
             cd - > /dev/null
-          done < <(find -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
+          done < <(find . -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
       - name: Publish to crates.io
         run: cargo publish
         env:

--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -60,13 +60,13 @@ jobs:
             cd "$grammar_dir"
             npm x -- tree-sitter generate
             cd - > /dev/null
-          done < <(find -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
+          done < <(find . -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
       - name: Build Wasm binaries
         shell: bash
         run: |-
           while read -r grammar; do
             npm x -- tree-sitter build --wasm "${grammar%/grammar.js}"
-          done < <(find -name grammar.js -not -path './node_modules/*')
+          done < <(find . -name grammar.js -not -path './node_modules/*')
       - name: Upload binaries
         uses: actions/upload-artifact@v4
         with:
@@ -102,7 +102,7 @@ jobs:
             cd "$grammar_dir"
             npm x -- tree-sitter generate
             cd - > /dev/null
-          done < <(find -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
+          done < <(find . -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
       - name: Build x64 binary
         run: npm x -- prebuildify --strip --arch x64 --target 20.9.0
       - name: Build arm64 binary

--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -55,7 +55,7 @@ jobs:
             cd "$grammar_dir"
             tree-sitter generate
             cd - > /dev/null
-          done < <(find -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
+          done < <(find . -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
       - name: Install dependencies
         run: pip install --upgrade pip build setuptools wheel
       - name: Build sources
@@ -101,7 +101,7 @@ jobs:
             cd "$grammar_dir"
             tree-sitter generate
             cd - > /dev/null
-          done < <(find -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
+          done < <(find . -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21
         with:

--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -58,7 +58,7 @@ jobs:
             cd "$grammar_dir"
             npm x -- tree-sitter generate
             cd - > /dev/null
-          done < <(find -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
+          done < <(find . -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
       - name: Update scanner
         if: inputs.update-scanner == true
         run: |-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,13 @@ jobs:
             pushd "$grammar_dir"
             tree-sitter generate
             popd > /dev/null
-          done < <(find -name grammar.js -not -path './node_modules/*')
+          done < <(find . -name grammar.js -not -path './node_modules/*')
       - name: Build Wasm binaries
         shell: bash
         run: |-
           while read -r grammar; do
             tree-sitter build --wasm "${grammar%/grammar.js}"
-          done < <(find -name grammar.js -not -path './node_modules/*')
+          done < <(find . -name grammar.js -not -path './node_modules/*')
       - name: Create source code tarball
         run: |
           git ls-files > "$RUNNER_TEMP/files"
@@ -66,7 +66,7 @@ jobs:
             printf '%s\n' >> "$RUNNER_TEMP/files" \
               "$src_dir"/parser.c "$src_dir"/grammar.json \
               "$src_dir"/node-types.json "$src_dir"/tree_sitter/*
-          done < <(find -name grammar.js -not -path './node_modules/*')
+          done < <(find . -name grammar.js -not -path './node_modules/*')
           tar cvJf "$REPO_NAME.tar.xz" -T <(sort -u "$RUNNER_TEMP/files")
       - name: Generate attestations
         uses: actions/attest-build-provenance@v1


### PR DESCRIPTION
## What

When using the [Regenerate parser step](https://github.com/DerekStride/tree-sitter-sql/actions/runs/11920711451/job/33223263797) for publishing to pypi I noticed an error with the `find` command on MacOS runners.

<img width="596" alt="Screenshot 2024-11-19 at 16 33 48" src="https://github.com/user-attachments/assets/9c7c647e-d164-4ec8-afcf-9d5c4d321cfe">

I was able to reproduce that on MacOS and discovered it's because MacOS ships with [BSD find](https://man.freebsd.org/cgi/man.cgi?find(1)) instead of [GNU find](https://man7.org/linux/man-pages/man1/find.1.html) which requires a starting directory.

## Fix

[GNU find](https://man7.org/linux/man-pages/man1/find.1.html) also supports the starting position so to fix the issue we can add that to the command.

### GNU find

<img width="355" alt="Screenshot 2024-11-19 at 16 30 08" src="https://github.com/user-attachments/assets/fb5d37b8-833e-4342-a1cf-0f3e1912510c">

### BSD find

<img width="545" alt="Screenshot 2024-11-19 at 16 29 28" src="https://github.com/user-attachments/assets/2893406a-e408-4666-8f73-11c0ed50c549">