### PR TITLE
feat: add abi input params

### DIFF
--- a/.github/workflows/package-crates.yml
+++ b/.github/workflows/package-crates.yml
@@ -19,6 +19,10 @@ on:
         description: Generate the parser artifacts
         default: false
         type: boolean
+      abi-version:
+        description: The tree-sitter ABI version
+        default: "15"
+        type: string
     secrets:
       CARGO_REGISTRY_TOKEN:
         description: An authentication token for crates.io
@@ -56,6 +60,8 @@ jobs:
             tree-sitter generate
             cd - > /dev/null
           done < <(find . -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
+        env:
+          TREE_SITTER_ABI_VERSION: ${{inputs.abi-version}}
       - name: Publish to crates.io
         run: cargo publish
         env:

--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -27,6 +27,10 @@ on:
         description: Generate the parser artifacts
         default: false
         type: boolean
+      abi-version:
+        description: The tree-sitter ABI version
+        default: "15"
+        type: string
     secrets:
       NODE_AUTH_TOKEN:
         description: An authentication token for npm
@@ -61,6 +65,8 @@ jobs:
             npm x -- tree-sitter generate
             cd - > /dev/null
           done < <(find . -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
+        env:
+          TREE_SITTER_ABI_VERSION: ${{inputs.abi-version}}
       - name: Build Wasm binaries
         shell: bash
         run: |-

--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -19,6 +19,10 @@ on:
         description: Generate the parser artifacts
         default: false
         type: boolean
+      abi-version:
+        description: The tree-sitter ABI version
+        default: "15"
+        type: string
     secrets:
       # TODO: make optional when pypi/warehouse#11096 is fixed
       PYPI_API_TOKEN:
@@ -56,6 +60,8 @@ jobs:
             tree-sitter generate
             cd - > /dev/null
           done < <(find . -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
+        env:
+          TREE_SITTER_ABI_VERSION: ${{inputs.abi-version}}
       - name: Install dependencies
         run: pip install --upgrade pip build setuptools wheel
       - name: Build sources
@@ -75,10 +81,10 @@ jobs:
         include:
           - { os: windows-latest, cibw_arch: AMD64 }
           - { os: windows-latest, cibw_arch: ARM64 }
-          - { os: ubuntu-latest,  cibw_arch: x86_64 }
-          - { os: ubuntu-latest,  cibw_arch: aarch64, qemu_arch: arm64 }
-          - { os: macos-latest,   cibw_arch: arm64 }
-          - { os: macos-latest,   cibw_arch: x86_64 }
+          - { os: ubuntu-latest, cibw_arch: x86_64 }
+          - { os: ubuntu-latest, cibw_arch: aarch64, qemu_arch: arm64 }
+          - { os: macos-latest, cibw_arch: arm64 }
+          - { os: macos-latest, cibw_arch: x86_64 }
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ on:
         description: Generate attestations for artifacts
         default: false
         type: boolean
+      abi-version:
+        description: The tree-sitter ABI version
+        default: "15"
+        type: string
 
 permissions:
   contents: write
@@ -52,6 +56,8 @@ jobs:
             tree-sitter generate
             popd > /dev/null
           done < <(find . -name grammar.js -not -path './node_modules/*')
+        env:
+          TREE_SITTER_ABI_VERSION: ${{inputs.abi-version}}
       - name: Build Wasm binaries
         shell: bash
         run: |-


### PR DESCRIPTION
Currently, there is no way to override the ABI version during publish, as you can't apply the `env` property to a re-usable workflow.

This PR aims to solve this by adding new inputs to each workflow for the `abi-version`. This is then applied using the `env` property in the generate steps. The default value if omitted is 15.

Thanks,
D