### PR TITLE
fix(package-pypi): Use inputs.abi-version also for build_wheels

### DIFF
--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -108,6 +108,8 @@ jobs:
             tree-sitter generate
             cd - > /dev/null
           done < <(find . -name grammar.js -not -path './node_modules/*' -not -path './.build/*')
+        env:
+          TREE_SITTER_ABI_VERSION: ${{inputs.abi-version}}
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23
         with:


### PR DESCRIPTION
If using the package-pypi workflow like this

```yaml
  pypi:
    uses: tree-sitter/workflows/.github/workflows/package-pypi.yml@main
    secrets:
      PYPI_API_TOKEN: ${{secrets.PYPI_API_TOKEN}}
    with:
      generate: true
      abi-version: 14
```

a sdist with ABI 14 and a wheel with ABI 15 will be uploaded to pypi, because only the sdist `tree-sitter generate` will have an explicit `TREE_SITTER_ABI_VERSION` set while the wheel job regenerates using the CLI default.

To generate and upload consistent artifacts, set `TREE_SITTER_ABI_VERSION` for both jobs, build_sdist and build_wheels.