### PR TITLE
Fix \r and missing tree-sitter command

### DIFF
--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           while read -r grammar_dir; do
             pushd "$grammar_dir"
-            tree-sitter generate
+            npm x -- tree-sitter generate
             popd > /dev/null
           done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
         env:
@@ -96,8 +96,9 @@ jobs:
         shell: bash
         run: |
           while read -r grammar_dir; do
+            grammar_dir="${grammar_dir%$'\r'}"
             pushd "$grammar_dir"
-            tree-sitter generate
+            npm x -- tree-sitter generate
             popd > /dev/null
           done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
       - name: Build binary

--- a/.github/workflows/package-pypi.yml
+++ b/.github/workflows/package-pypi.yml
@@ -114,6 +114,7 @@ jobs:
         shell: bash
         run: |
           while read -r grammar_dir; do
+            grammar_dir="${grammar_dir%$'\r'}"
             pushd "$grammar_dir"
             tree-sitter generate
             popd > /dev/null


### PR DESCRIPTION
Close #55 and fix a `tree-sitter command not found` in npm build