### PR TITLE
feat: add swap-size parameter for Wasm builds that need more memory

### DIFF
--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -23,6 +23,14 @@ on:
         description: The tree-sitter ABI version
         default: 15
         type: number
+      swap-size:
+        description: >
+          Resize the runner swap space before the Wasm build.
+          Set to a size such as "64G" to allocate that much swap, or leave
+          as "normal" (the default) to skip the resize entirely.
+          Useful for grammars whose Wasm compilation exceeds available memory.
+        default: normal
+        type: string
     secrets:
       NODE_AUTH_TOKEN:
         description: An authentication token for npm
@@ -57,6 +65,17 @@ jobs:
           done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
         env:
           TREE_SITTER_ABI_VERSION: ${{inputs.abi-version}}
+      - name: Increase swap space
+        if: inputs.swap-size != 'normal'
+        run: |
+          sudo swapoff -a
+          sudo fallocate -l "$SWAP_SIZE" /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          sudo swapon --show
+        env:
+          SWAP_SIZE: ${{inputs.swap-size}}
       - name: Build Wasm binaries
         run: |-
           while read -r grammar_dir; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,14 @@ on:
         description: The tree-sitter ABI version
         default: 15
         type: number
+      swap-size:
+        description: >
+          Resize the runner swap space before the Wasm build.
+          Set to a size such as "64G" to allocate that much swap, or leave
+          as "normal" (the default) to skip the resize entirely.
+          Useful for grammars whose Wasm compilation exceeds available memory.
+        default: normal
+        type: string
 
 permissions:
   contents: write
@@ -54,6 +62,17 @@ jobs:
           done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
         env:
           TREE_SITTER_ABI_VERSION: ${{inputs.abi-version}}
+      - name: Increase swap space
+        if: inputs.swap-size != 'normal'
+        run: |
+          sudo swapoff -a
+          sudo fallocate -l "$SWAP_SIZE" /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          sudo swapon --show
+        env:
+          SWAP_SIZE: ${{inputs.swap-size}}
       - name: Build Wasm binaries
         shell: bash
         run: |-


### PR DESCRIPTION
Some grammars (e.g. `tree-sitter-zsh`) exceed available memory during Wasm compilation on GitHub Actions runners. Currently consumers work around this by maintaining local copies of `release.yml` and `package-npm.yml` with a swap resize step injected before the Wasm build — which means tracking upstream changes manually.

This PR adds an optional `swap-size` input to both workflows:

- **Default: `normal`** — skips the resize entirely; no behaviour change for existing consumers.
- **Set to e.g. `64G`** — allocates that much swap before the Wasm build step.

## Usage

```yaml
# release.yml
jobs:
  release:
    uses: tree-sitter/workflows/.github/workflows/release.yml@main
    with:
      swap-size: 64G

# publish.yml
jobs:
  npm:
    uses: tree-sitter/workflows/.github/workflows/package-npm.yml@main
    with:
      swap-size: 64G
```

## Changes

* `.github/workflows/release.yml` - New `swap-size` input; conditional "Increase swap space" step before "Build Wasm binaries"
* `.github/workflows/package-npm.yml` - Same — `swap-size` input and conditional swap step in the `build_wasm` job

## Why not just fix the compiler?

This may become unnecessary if upstream changes decrease appetite for memory for wasm compiles.  It's also likely that grammar optimization may help.  However, this allows folks with issues to keep using the official treesitter workflows rather than having to copy and modify them.